### PR TITLE
Enable to pass a custom `requests.Session`

### DIFF
--- a/redash_python/redash.py
+++ b/redash_python/redash.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Optional
 
 import requests
 
@@ -32,10 +32,10 @@ class Redash:
         >>> rd.dashboards.get_all()
     """
 
-    def __init__(self, base_url: str, api_key: str) -> None:
+    def __init__(self, base_url: str, api_key: str, session: Optional[requests.Session] = None) -> None:
         self.version = version
 
-        self.__base = BaseService(base_url, api_key)
+        self.__base = BaseService(base_url, api_key, session=session)
 
         # Initialize services
         self.dashboards = DashboardsService(self.__base)

--- a/redash_python/services/base.py
+++ b/redash_python/services/base.py
@@ -6,15 +6,19 @@ import requests
 class BaseService:
     """Singleton Base Service class"""
 
-    def __init__(self, base_url: str, api_key: str, **kwargs) -> None:
+    def __init__(self, base_url: str, api_key: str, session: Optional[requests.Session], **kwargs) -> None:
         self.base_url = base_url
         super().__init__(**kwargs)
 
-        # configure session
-        self.__session = requests.Session()
-        self.__session.headers.update({"Authorization": f"Key {api_key}"})
-        self.__session.headers.update({"Content-Type": "application/json"})
-        self.__session.headers.update({"Accept": "application/json"})
+        # Enable to pass a custom session
+        if session is not None and isinstance(session, requests.Session):
+            self.__session = session
+        else:
+            # configure session
+            self.__session = requests.Session()
+            self.__session.headers.update({"Authorization": f"Key {api_key}"})
+            self.__session.headers.update({"Content-Type": "application/json"})
+            self.__session.headers.update({"Accept": "application/json"})
 
     @final
     def _request(


### PR DESCRIPTION
Resolves https://github.com/Blacksuan19/redash-python/issues/4

## Overview
We would like to pass a custom `requests.Session` to `BaseService` so that we can customize the header. The reason why I implemented it is that we have to pass multiple values of the `Authorization` header to pass an ID token of Cloud IAP and a redash API token at the same time. We can also implement alternative way. However, it might be a bit simpler to pass a custom header to `BaseService`.

```
Authorization: Bearer XXXXXXXXXX, Key XXXXXXXXXXXX
```
